### PR TITLE
Feature improve categories page

### DIFF
--- a/app/admin/category.rb
+++ b/app/admin/category.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register Category do
 
-  permit_params :name, :description, :locale, :image_url
+  permit_params :name, :position, :description, :locale, :image_url
 
   filter :name
   filter :description
@@ -11,6 +11,7 @@ ActiveAdmin.register Category do
   index do
     column(:id)
     column(:name)
+    column(:position)
     column(:description)
     column(:locale)
     column(:image_url)

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,5 +1,5 @@
 class CategoriesController < ApplicationController
   def index
-    @categories = Category.at_locale
+    @categories = Category.at_locale.order(:position)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -7,4 +7,12 @@ class Category < ActiveRecord::Base
   validates_presence_of :name, :description, :image_url
 
   markup_on :description
+
+  def single_path?
+    paths.size == 1
+  end
+
+  def single_path
+    paths.first
+  end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,8 +1,10 @@
 class Category < ActiveRecord::Base
-
   include WithLocale
+  include WithMarkup
 
   has_many :paths
 
   validates_presence_of :name, :description, :image_url
+
+  markup_on :description
 end

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -12,7 +12,7 @@
           <hr>
 
           <p>
-            <%= it.description %>
+            <%= it.description_html %>
           </p>
 
           <p>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -15,13 +15,17 @@
             <%= it.description_html %>
           </p>
 
-          <p>
-            <strong><%= t :category_languages_availability %> </strong>
-          </p>
-          <% it.paths.each do |path| %>
-            <a href="<%= guide_path(path.first_guide) %>" class="btn btn-success">
-              <%= image_tag path.language.image_url, height: 32 %> <%= path.language.name %>
-            </a>
+          <% if it.single_path? %>
+            <%= link_to t(:start_practicing), it.single_path.first_guide, class: 'btn btn-success'%>
+          <% else %>
+            <p>
+              <strong><%= t :category_languages_availability %> </strong>
+            </p>
+            <% it.paths.each do |path| %>
+              <a href="<%= guide_path(path.first_guide) %>" class="btn btn-success">
+                <%= image_tag path.language.image_url, height: 32 %> <%= path.language.name %>
+              </a>
+            <% end %>
           <% end %>
         </div>
       </div>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -15,7 +15,7 @@ es:
   cancel: Cancelar
   categories_index_title: ¿Qué te gustaría aprender?
   category: Categoría
-  category_languages_availability: Disponible en los siguientes lenguajes
+  category_languages_availability: ¡Elegí el lenguaje que querés usar!
   collaborators_refreshed: Lista de collaboradores actualizada
   comma_or_tab_separated: Separados por tab o coma!
   continue_practicing: ¡Seguí practicando!

--- a/db/migrate/20150708212022_add_position_to_category.rb
+++ b/db/migrate/20150708212022_add_position_to_category.rb
@@ -1,0 +1,5 @@
+class AddPositionToCategory < ActiveRecord::Migration
+  def change
+    add_column :categories, :position, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20150708212836_change_category_description_to_text.rb
+++ b/db/migrate/20150708212836_change_category_description_to_text.rb
@@ -1,0 +1,5 @@
+class ChangeCategoryDescriptionToText < ActiveRecord::Migration
+  def change
+    change_column :categories, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150708212022) do
+ActiveRecord::Schema.define(version: 20150708212836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 20150708212022) do
 
   create_table "categories", force: true do |t|
     t.string   "name"
-    t.string   "description"
+    t.text     "description"
     t.string   "locale"
     t.string   "image_url"
     t.datetime "created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150701212609) do
+ActiveRecord::Schema.define(version: 20150708212022) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 20150701212609) do
     t.string   "image_url"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "position",    default: 0, null: false
   end
 
   create_table "collaborators", force: true do |t|

--- a/spec/features/standard_flow_spec.rb
+++ b/spec/features/standard_flow_spec.rb
@@ -3,27 +3,51 @@ require 'spec_helper'
 feature 'Standard Flow' do
   let(:haskell) { create(:haskell) }
   let!(:exercises) {
-    create(:exercise, title: 'Succ',        guide: guide, position: 1, description: 'Description of foo')
+    create(:exercise, title: 'Succ', guide: guide, position: 1, description: 'Description of foo')
   }
   let!(:category) { create(:category, name: 'Functional Programming') }
   let!(:path) { create(:path, category: category, language: haskell) }
   let!(:guide) { create(:guide, name: 'getting-started', description: 'An awesome guide',
                         language: haskell, position: 1, path: path) }
 
-  scenario 'do a guide for first time, starting from home' do
+
+  before do
     visit '/'
+  end
 
-    within('.jumbotron') do
+  context 'single path' do
+    scenario 'do a guide for first time, starting from home' do
+      within('.jumbotron') do
+        click_on 'Start Practicing!'
+      end
+
+      within('.category-panel') do
+        click_on 'Start Practicing!'
+      end
+
       click_on 'Start Practicing!'
+      expect(page).to have_text('Succ')
     end
+  end
 
-    within('.category-panel') do
-      click_on 'haskell'
+  context 'multiple paths' do
+    let(:js) { create(:language, name: 'js') }
+    let!(:path_js) { create(:path, category: category, language: js) }
+    let!(:guide_js) { create(:guide, name: 'getting-started-js', description: 'An awesome JS guide',
+                             language: js, position: 1, path: path_js) }
+
+    scenario 'do a guide for first time, starting from home' do
+      within('.jumbotron') do
+        click_on 'Start Practicing!'
+      end
+
+      within('.category-panel') do
+        click_on 'haskell'
+      end
+
+      click_on 'Start Practicing!'
+      expect(page).to have_text('Succ')
     end
-
-    click_on 'Start Practicing!'
-
-    expect(page).to have_text('Succ')
   end
 
 


### PR DESCRIPTION
With this PR we get:

* a consistent ordering of categories in category page - based on a position assigned by admin
* markdown categories description
* no language choosing message when there is only one path per category. 

With those changes, there is no need of implementing #188, since it can be added or linked directly from category description.  

Closes #188 