### PR TITLE
272 default import properties

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -42,16 +42,16 @@ class Import < RepositoryOperation
 
     guide.language = Language.find_by_ignore_case! :name, meta['language']
     guide.locale = meta['locale']
-    read_optional! meta, 'original_id_format'
-    read_optional! meta, 'learning'
-    read_optional! meta, 'beta'
+    read_optional! meta, 'original_id_format', '%05d'
+    read_optional! meta, 'learning', false
+    read_optional! meta, 'beta', false
     guide.save!
 
     meta['order']
   end
 
-  def read_optional!(meta, key)
-    meta[key].try { |value| guide[key] = value }
+  def read_optional!(meta, key, default)
+    guide[key] = meta[key] || default
   end
 
   def read_exercises!(dir, order = nil)

--- a/spec/models/import_spec.rb
+++ b/spec/models/import_spec.rb
@@ -58,7 +58,6 @@ describe Import do
         it { expect(imported_exercise.corollary).to eq "And the corollary is...\n" }
       end
 
-
       context 'when importing with layout' do
         let(:imported_exercise) { Exercise.find_by(guide_id: guide.id, original_id: 4) }
 
@@ -83,6 +82,24 @@ describe Import do
       it { expect(guide.learning).to be true }
       it { expect(guide.beta).to eq true }
       it { expect(guide.extra_code).to eq "A guide's extra code\n" }
+    end
+
+    context 'when optional properties are specified' do
+      before do
+        import.read_guide! 'spec/data/full-guide'
+        guide.reload
+      end
+
+      context 'when removing that properties and reimporting the guide' do
+        before do
+          import.read_guide! 'spec/data/simple-guide'
+          guide.reload
+        end
+
+        it { expect(guide.original_id_format).to eq '%05d' }
+        it { expect(guide.learning).to be false }
+        it { expect(guide.beta).to be false }
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #272 

This PR adds default values for optional properties.

When a guide is loaded without ***original_id_format***, ***learning*** and/or ***beta*** properties, 
asigns *'%05d'*, *false* and *false* values, respectively.