### PR TITLE
More fine grained version specifiers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,10 @@ ruby '2.0.0'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.1.4'
 
-gem 'pg'
-gem 'pg_search'
+gem 'pg', '~> 0.18.0'
+gem 'pg_search', '~> 1.0'
 
-gem 'uglifier', '>= 1.3.0'
+gem 'uglifier', '~> 2.7'
 
 gem 'therubyracer', platforms: :ruby
 
@@ -29,7 +29,7 @@ source 'https://rails-assets.org' do
   gem 'rails-assets-bootstrap-vertical-tabs'
 end
 
-gem 'chartkick'
+gem 'chartkick', '~> 1.4'
 
 gem 'omniauth-github'
 gem 'omniauth-facebook'
@@ -37,17 +37,17 @@ gem 'omniauth-facebook'
 gem 'font-awesome-rails'
 
 gem 'rouge', :github => 'jneen/rouge', :ref => 'dbdd4e7d249606543831dba63efc2737b7d6ad90'
-gem 'redcarpet'
+gem 'redcarpet', '~> 3.3.2'
 gem 'md_emoji'
 
-gem 'ace-rails-ap'
+gem 'ace-rails-ap', '~> 4.0'
 
 gem 'unicorn-rails'
 
 gem 'acts-as-taggable-on', '~> 3.4'
 
 gem 'git'
-gem 'octokit'
+gem 'octokit', '~> 4.1'
 gem 'kaminari'
 gem 'bootstrap-kaminari-views'
 
@@ -66,8 +66,8 @@ gem 'mumukit-bridge',     :github => 'uqbar-project/mumukit-bridge', :tag=> 'v0.
 group :test do
   gem 'rspec-rails', '~> 2.14'
   gem 'factory_girl_rails'
-  gem 'rake'
-  gem 'faker'
+  gem 'rake', '10.4.2'
+  gem 'faker', '~> 1.5'
   gem 'capybara', '2.3.0'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'acts-as-taggable-on', '~> 3.4'
 
 gem 'git'
 gem 'octokit', '~> 4.1'
-gem 'kaminari'
+gem 'kaminari', '~> 0.16.3'
 gem 'bootstrap-kaminari-views'
 
 gem 'bootstrap_form'

--- a/Gemfile
+++ b/Gemfile
@@ -60,8 +60,8 @@ gem 'nprogress-rails'
 
 gem 'yaml_db'
 
-gem 'mumukit-inspection', :github => 'uqbar-project/mumukit-inspection', :branch => 'master'
-gem 'mumukit-bridge',     :github => 'uqbar-project/mumukit-bridge', :tag=> 'v0.3.0'
+gem 'mumukit-inspection', :github => 'mumuki/mumukit-inspection', :branch => 'master'
+gem 'mumukit-bridge',     :github => 'mumuki/mumukit-bridge', :tag=> 'v0.3.0'
 
 group :test do
   gem 'rspec-rails', '~> 2.14'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,7 +366,7 @@ DEPENDENCIES
   git
   i18n-tasks (~> 0.8.3)
   jquery-rails
-  kaminari
+  kaminari (~> 0.16.3)
   md_emoji
   mumukit-bridge!
   mumukit-inspection!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,7 +347,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ace-rails-ap
+  ace-rails-ap (~> 4.0)
   activeadmin (~> 1.0.0.pre1)
   acts-as-taggable-on (~> 3.4)
   better_errors
@@ -355,12 +355,12 @@ DEPENDENCIES
   bootstrap-kaminari-views
   bootstrap_form
   capybara (= 2.3.0)
-  chartkick
+  chartkick (~> 1.4)
   codeclimate-test-reporter
   devise
   execjs
   factory_girl_rails
-  faker
+  faker (~> 1.5)
   font-awesome-rails
   friendly_id (~> 5.0.0)
   git
@@ -371,18 +371,18 @@ DEPENDENCIES
   mumukit-bridge!
   mumukit-inspection!
   nprogress-rails
-  octokit
+  octokit (~> 4.1)
   omniauth-facebook
   omniauth-github
-  pg
-  pg_search
+  pg (~> 0.18.0)
+  pg_search (~> 1.0)
   rails (= 4.1.4)
   rails-assets-bootstrap!
   rails-assets-bootstrap-tagsinput!
   rails-assets-bootstrap-vertical-tabs!
   rails-i18n (~> 4.0.0)
-  rake
-  redcarpet
+  rake (= 10.4.2)
+  redcarpet (~> 3.3.2)
   rouge!
   rspec-rails (~> 2.14)
   sass-rails
@@ -390,6 +390,9 @@ DEPENDENCIES
   sucker_punch (~> 1.0)
   therubyracer
   turbolinks
-  uglifier (>= 1.3.0)
+  uglifier (~> 2.7)
   unicorn-rails
   yaml_db
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GIT
     rouge (1.9.0)
 
 GIT
-  remote: git://github.com/uqbar-project/mumukit-bridge.git
+  remote: git://github.com/mumuki/mumukit-bridge.git
   revision: 4c178dd71c6f38e93f2cfdca0db14226d777b6c3
   tag: v0.3.0
   specs:
@@ -15,8 +15,8 @@ GIT
       rest-client
 
 GIT
-  remote: git://github.com/uqbar-project/mumukit-inspection.git
-  revision: 7c29d27aaaa52b021a9d6c7ad0e9c7b4b39fa205
+  remote: git://github.com/mumuki/mumukit-inspection.git
+  revision: 11f0a129b18138336a2d2b1c9b72b97b2f34b208
   branch: master
   specs:
     mumukit-inspection (0.0.1)


### PR DESCRIPTION
This PR discourages big changes of gem version without notice. 

Only doing so for gems that are core, do not depend on external services and change frequently. 